### PR TITLE
Use IndexSpec.KeyPath for store keyPath

### DIFF
--- a/Blazor.IndexedDB.JS/src/indexedDbBlazor.ts
+++ b/Blazor.IndexedDB.JS/src/indexedDbBlazor.ts
@@ -204,7 +204,7 @@ export class IndexedDbManager {
             primaryKey = { name: 'id', keyPath: 'id', auto: true };
         }
 
-        const newStore = upgradeDB.createObjectStore(store.name, { keyPath: primaryKey.name, autoIncrement: primaryKey.auto });
+        const newStore = upgradeDB.createObjectStore(store.name, { keyPath: primaryKey.keyPath, autoIncrement: primaryKey.auto });
 
         for (var index of store.indexes) {
             newStore.createIndex(index.name, index.keyPath, { unique: index.unique });


### PR DESCRIPTION
IndexedDBManager.AddNewStore incorrectly uses IndexSpec.Name as the key path for the primary key of the new object store.